### PR TITLE
aggiunta info sul plugin MKS Wifi di Cura

### DIFF
--- a/docs/slicer/cura/cura.md
+++ b/docs/slicer/cura/cura.md
@@ -5,6 +5,10 @@ slug: /slicer/cura
 
 Lo slicer piu' diffuso tra i membri della community, contiene gia' le impostazioni per la flyingbear ghost (dalla 4.6.0 quello per la 4s, dalla 4.8.0 quello per la 5)
 
+Cura ha un **plugin per controllare la stampante FlyingBearGhost 5 tramite WiFi** (che funziona se avete connesso la stampante alla vostra rete wifi di casa). Non è potente come octoprint o altri ma permette di fare operazioni di base come mandare i file gcode (che vengono salvati sulla scheda SD) e avviare la stampa appena sono stati trasferiti, vedere/cancellare/stampare di nuovo dei file gcode già presenti sulla SD, mandare dei comandi Gcode, vedere le temperature e dare dei comandi di movimento degli assi
+Si chiama **MKS WiFi Plugin** ed è possibile scaricarlo dal marketplace di Cura (lo store dei plugin interno al programma stesso).
+FlyingBear ha alcuni video su youtube tra cui il [video dove mostra la configurazione di questo plugin](https://www.youtube.com/watch?v=cTkhWAsnMXE&t=420s)  (la versione più vecchia, ma è la stessa cosa).
+
 [Scarica qui (gratuito)](https://ultimaker.com/software/ultimaker-cura)
 
 *  [I migliori plugin di cura](https://all3dp.com/2/5-must-have-cura-plugins)


### PR DESCRIPTION
permette di mandare stampe e dare comandi di base alla stampante